### PR TITLE
I've added new producer, segment, and interpreter classes (timestamp …

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,13 +5,13 @@
  */
 
 import * as p5 from "p5";
-import { Segment202505271310 as Segment } from "./segments/segment-202505271310";
-import { Producer202505271720 as Producer } from "./producers/producer-202505271720";
-import { Interpreter202505271211 as Interpreter } from "./interpreters/interpreter-202505271211";
+import { Segment202505280000 as Segment } from "./segments/segment-202505280000";
+import { Producer202505280000 as Producer } from "./producers/producer-202505280000";
+import { Interpreter202505280000 as Interpreter } from "./interpreters/interpreter-202505280000";
 import { Turtle } from "./turtle/turtle";
 import { Random } from "./utils/randomness";
 
-let system = new Segment(20, 0, 0, 0);
+let system = new Segment(20, 0, 0, 0, 0); // Added offset 0
 let producer = new Producer(Segment);
 
 const sketch2 = (p: p5) => {
@@ -55,13 +55,13 @@ document.getElementById("btn3")?.addEventListener("click", () => {
   const struct = JSON.parse(
     (document.getElementById("procedure-def") as HTMLTextAreaElement).value
   );
-  system = new Segment(0, 0, 0, 0);
+  system = new Segment(0, 0, 0, 0, 0); // Added offset 0
   producer = new Producer(Segment);
   producer.load(struct);
 });
 
 function loadSeed(seed: string) {
-  system = new Segment(0, 0, 0, 0);
+  system = new Segment(0, 0, 0, 0, 0); // Added offset 0
   producer = new Producer(Segment);
   producer.mutate(new Random(seed));
   (document.getElementById("procedure-def") as HTMLTextAreaElement).value =

--- a/src/interpreters/interpreter-202505280000.ts
+++ b/src/interpreters/interpreter-202505280000.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 Beka Westberg
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Segment as BaseSegment } from "../segments/segment";
+// Using ActualSegmentClass for clarity on what segment structure is expected.
+import { Segment202505280000 as ActualSegmentClass } from '../segments/segment-202505280000';
+import { Turtle } from "../turtle/turtle";
+
+// This interface defines the structure of segments that this interpreter can handle.
+export interface SegmentForInterpreter202505280000 extends BaseSegment {
+  length: number;
+  angle: number;
+  offset: number; // Crucial for this interpreter
+  children: this[]; // Children should also conform to this interface
+}
+
+export class Interpreter202505280000 {
+  constructor(public readonly turtle: Turtle) {}
+
+  /** Recursively interprets the segment. */
+  interpret(segment: SegmentForInterpreter202505280000): void {
+    this.turtle.pushState();
+    this.turtle.left(segment.angle);
+    this.turtle.forward(segment.length); // Draw the current segment
+
+    // Children are drawn relative to the start of the current segment, using their offset
+    for (const child of segment.children) {
+      // Cast child to the correct type if necessary, assuming children are of the same compatible type
+      // The interface SegmentForInterpreter202505280000 already defines the necessary properties.
+      const childSegment = child as SegmentForInterpreter202505280000;
+
+      // 1. Move from parent's end to child's start point (relative to parent's start)
+      // Parent's length is segment.length. Child's offset is childSegment.offset.
+      // The distance from parent's end back to child's start is segment.length - childSegment.offset.
+      // So, move turtle backward by this amount.
+      this.turtle.forward(-(segment.length - childSegment.offset));
+
+      // 2. Interpret the child segment.
+      // This will involve its own angle turn and forward movement for its length.
+      this.interpret(childSegment);
+
+      // 3. Return turtle to the end of the parent segment.
+      // After child.interpret() finishes, turtle is at the end of the child.
+      // We need to move it back to where it was before drawing this specific child,
+      // which is the end of the parent segment.
+      // This is the reverse of the movement in step 1.
+      this.turtle.forward(segment.length - childSegment.offset);
+    }
+    this.turtle.popState();
+  }
+}

--- a/src/producers/producer-202505280000.ts
+++ b/src/producers/producer-202505280000.ts
@@ -1,0 +1,117 @@
+/**
+ * @license
+ * Copyright 2025 Beka Westberg
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Segment as BaseSegment } from "../segments/segment";
+import { Segment202505280000 as ActualSegmentClass } from '../segments/segment-202505280000';
+import { Producer } from "./producer";
+import { Linear } from "../functions/linear";
+import { Power } from "../functions/power";
+import { Clamp } from "../functions/clamp";
+import { Constant as C } from "../mods/constant";
+import { Clamped as Cl } from "../mods/clamped";
+import { Random } from "../utils/randomness";
+
+// This interface is for type consistency with how other producers are written,
+// even if ActualSegmentClass could be used directly in some places.
+export interface Segment202505280000 extends BaseSegment {
+  length: number;
+  angle: number;
+  stage: number;
+  age: number;
+  offset: number; // Added offset
+  children: this[];
+}
+
+export interface Segment202505280000Constructor<S extends Segment202505280000> {
+  new (length: number, angle: number, stage: number, age: number, offset: number): S; // Added offset
+}
+
+export class Producer202505280000<
+  S extends Segment202505280000,
+> extends Producer<S> {
+  // All these functions remain the same as Producer202505271720
+  private readonly modifyAge = new Clamp(
+    new C(0),
+    new C(1),
+    new Linear(new Cl(1, 1, 2), new Cl(0.2, 0.01, 0.5))
+  );
+  private readonly modifyLength = new Linear(
+    new Cl(60, 0, 100),
+    new C(0),
+    new Clamp(new C(0), new C(1))
+  );
+  private readonly newChildCount = new Power(
+    new Cl(-3.5, -10, -1),
+    new Cl(0.4, 0, 1),
+    new Cl(0.3, 0, 2),
+    new Cl(3, 0, 10)
+  );
+  private readonly newChildStage = new Linear(
+    new Cl(1, 1, 2),
+    new Cl(0.2, 0.01, 0.5)
+  );
+  private readonly newChildAngle = new Linear(
+    new Cl(-45, -90, 0),
+    new Cl(45, 0, 90)
+  );
+
+  constructor(
+    // Use ActualSegmentClass for the constructor parameter type for clarity
+    public readonly segmentConstructor: Segment202505280000Constructor<S & ActualSegmentClass>
+  ) {
+    super();
+  }
+
+  produce(segment: S): S {
+    const newSegment = segment.duplicate() as S; // Ensure newSegment is of type S
+    newSegment.age = this.modifyAge.eval(segment.age);
+    newSegment.length = this.modifyLength.eval(segment.age - segment.stage);
+
+    const newChildCount = this.newChildCount.eval(segment.stage + segment.age);
+    for (let i = 0; i < newChildCount; i++) {
+      newSegment.children.push(
+        new this.segmentConstructor(
+          0, // Initial length for new children
+          this.newChildAngle.eval(i),
+          this.newChildStage.eval(segment.stage),
+          0, // Initial age for new children
+          segment.length // *** Offset is parent's current length ***
+        )
+      );
+    }
+    // Recursively produce for existing children. Their offsets are preserved by their own duplicate() methods.
+    const existingChildren = segment.children.map(child => this.produce(child as S));
+    newSegment.children.push(...existingChildren);
+    
+    return newSegment;
+  }
+
+  mutate(random: Random): void {
+    this.modifyAge.mutate(random);
+    this.modifyLength.mutate(random);
+    this.newChildCount.mutate(random);
+    this.newChildStage.mutate(random);
+    this.newChildAngle.mutate(random);
+  }
+
+  save(): Record<string, any> {
+    return {
+      modifyAge: this.modifyAge.save(),
+      modifyLength: this.modifyLength.save(),
+      newChildCount: this.newChildCount.save(),
+      newChildStage: this.newChildStage.save(),
+      newChildAngle: this.newChildAngle.save(),
+    };
+  }
+
+  load(data: Record<string, any>) {
+    this.modifyAge.load(data.modifyAge);
+    this.modifyLength.load(data.modifyLength);
+    this.newChildCount.load(data.newChildCount);
+    this.newChildStage.load(data.newChildStage);
+    this.newChildAngle.load(data.newChildAngle);
+  }
+}

--- a/src/segments/segment-202505280000.ts
+++ b/src/segments/segment-202505280000.ts
@@ -1,0 +1,42 @@
+/**
+ * @license
+ * Copyright 2025 Beka Westberg
+ * SPDX-License-Identifier: MIT
+ */
+
+import { Segment } from "./segment";
+
+export class Segment202505280000 extends Segment {
+  children: Segment202505280000[] = [];
+
+  /**
+   * @param length The length of the segment in pixels.
+   * @param angle The angle to turn left by before drawing the segment in degrees.
+   *   @param stage The stage of the segment.
+   * @param age The age of the segment.
+   * @param offset The offset of this segment from the start of its parent.
+   */
+  constructor(
+    public length: number,
+    public angle: number,
+    public readonly stage: number,
+    public age: number,
+    public offset: number,
+  ) {
+    super();
+  }
+
+  duplicate(): this {
+    const result = new Segment202505280000(
+      this.length,
+      this.angle,
+      this.stage,
+      this.age,
+      this.offset,
+    );
+    // Should children be duplicated here?
+    // Based on Segment202505271310, children are not duplicated in `duplicate()`.
+    // They are handled by the producer instead.
+    return result as this;
+  }
+}


### PR DESCRIPTION
…202505280000) to ensure that child segments maintain their absolute position relative to the start of their parent segment, even when the parent segment's length changes.

- `Segment202505280000` now includes an `offset` property.
- `Producer202505280000` initializes the child segment `offset` to the parent's length at the time of creation. This offset is preserved through subsequent duplications and productions.
- `Interpreter202505280000` uses the `offset` property to correctly position child segments by adjusting the turtle's position before and after rendering each child.
- I've updated `src/index.ts` to use these new classes.